### PR TITLE
Make clear immer is a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A hook to use [immer](https://github.com/mweststrate/immer) as a React [hook](ht
 
 # Installation
 
-`npm install use-immer`
+`npm install immer use-immer`
 
 # API
 


### PR DESCRIPTION
This wasn't obvious to me, even though quickly fixed.
Looking at other libraries READMEs it's quite common to make this clear by adding peer dependencies to the `npm install`.