### PR TITLE
Update immer 5.0 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "homepage": "https://github.com/mweststrate/use-immer#readme",
   "peerDependencies": {
-    "immer": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "immer": ">=2.0.0",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "@types/react": "^16.8.13",
-    "immer": "^4.0.0",
+    "immer": "^5.0.0",
     "microbundle": "^0.11.0",
     "typescript": "^3.4.3"
   }


### PR DESCRIPTION
I think it should be just fine to keep the range like `>=2.0.0` to avoid the need for updating it all the time. Given how minimalistic code of this lib is, it doesn't seem likely to have a breaking change there.