### PR TITLE
ImmerHook return type, Dispatch type fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import produce, { Draft } from "immer";
-import { useState, useReducer, useCallback, Dispatch } from "react";
+import { useState, useReducer, useCallback, useMemo, Dispatch } from "react";
 
 export type Reducer<S = any, A = any> = (
   draftState: Draft<S>,
@@ -28,6 +28,6 @@ export function useImmerReducer<S = any, A = any>(
   initialAction?: (initial: any) => S
 ): [S, Dispatch<A>];
 export function useImmerReducer(reducer, initialState, initialAction) {
-  const cachedReducer = useCallback(produce(reducer), [reducer]);
+  const cachedReducer = useMemo(() => produce(reducer), [reducer]);
   return useReducer(cachedReducer, initialState as any, initialAction);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type Reducer<S = any, A = any> = (
   action: A
 ) => void | S;
 
-export type ImmerHook<S> = [S, (f: (draft: Draft<S>) => void | S) => void]
+export type ImmerHook<S> = [S, (f: (draft: Draft<S>) => void | S) => void];
 
 export function useImmer<S = any>(
   initialValue: S | (() => S)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,17 @@
 import produce, { Draft } from "immer";
-import { useState, useReducer, useCallback } from "react";
+import { useState, useReducer, useCallback, Dispatch } from "react";
 
 export type Reducer<S = any, A = any> = (
   draftState: Draft<S>,
   action: A
 ) => void | S;
 
+export type ImmerHook<S> = [S, (f: (draft: Draft<S>) => void | S) => void]
+
 export function useImmer<S = any>(
   initialValue: S | (() => S)
 ): [S, (f: (draft: Draft<S>) => void | S) => void];
+
 export function useImmer(initialValue: any) {
   const [val, updateValue] = useState(initialValue);
   return [
@@ -23,7 +26,7 @@ export function useImmerReducer<S = any, A = any>(
   reducer: Reducer<S, A>,
   initialState: S,
   initialAction?: (initial: any) => S
-): [S, React.Dispatch<A>];
+): [S, Dispatch<A>];
 export function useImmerReducer(reducer, initialState, initialAction) {
   const cachedReducer = useCallback(produce(reducer), [reducer]);
   return useReducer(cachedReducer, initialState as any, initialAction);

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,9 +236,9 @@ acorn-jsx@^5.0.1:
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
 acorn@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
-  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 alphanum-sort@^1.0.0, alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Hello, I've encountered a situation where I needed the **return type of `useImmer<T>`**, however TypeScript's `ReturnType<T>` doesn't work with generic return types (https://github.com/Microsoft/TypeScript/issues/26856).

I would like to add a **type alias** for this return type ( `[T, (f: (d: Draft<T>) => T | void) => void]`) called `ImmerHook` (feel free to rename it appropriately).

Also I have noticed the `useImmerReducer<S, A>` uses `React.Dispatch`, however `React` is **not imported**. Is this intended ? I have fixed it by adding `{Dispatch}` import.