### PR TITLE
useImmerReducer: only call produce() when reducer changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import produce, { Draft } from "immer";
-import { useState, useReducer, useCallback } from "react";
+import { useState, useReducer, useCallback, useMemo } from "react";
 
 export type Reducer<S = any, A = any> = (
   draftState: Draft<S>,
@@ -25,6 +25,6 @@ export function useImmerReducer<S = any, A = any>(
   initialAction?: (initial: any) => S
 ): [S, React.Dispatch<A>];
 export function useImmerReducer(reducer, initialState, initialAction) {
-  const cachedReducer = useCallback(produce(reducer), [reducer]);
+  const cachedReducer = useMemo(() => produce(reducer), [reducer]);
   return useReducer(cachedReducer, initialState as any, initialAction);
 }


### PR DESCRIPTION
Previously, this called `produce()` on every render but discarded the result on every render where `reducer` didn't change. Now, we use useMemo, which only calls it when `reducer` changes. (useCallback is really only intended for a function literal first argument.)