### PR TITLE
add update type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ export type Reducer<S = any, A = any> = (
   action: A
 ) => void | S;
 
-export type ImmerHook<S> = [S, (f: (draft: Draft<S>) => void | S) => void];
+export type Update<S> = (f: (draft: Draft<S>) => void | S) => void;
+
+export type ImmerHook<S> = [S, Update<S>];
 
 export function useImmer<S = any>(
   initialValue: S | (() => S)


### PR DESCRIPTION
To specify `SetCountContextType`, it is written as `immerHook<S>[1]`.

So, I suggest `Update` type.

```js
const CountContext = React.createContext(0);

type SetCountContextType = ImmerHook<number>[1];
// type SetCountContextType = Update<number>;

const SetCountContext = React.createContext<SetCountContextType>(
  {} as SetCountContextType
);

export default function App() {
  const [count, produceCount] = useImmer(0);

  return (
    <CountContext.Provider value={count}>
      <SetCountContext.Provider value={produceCount}>
		{...}
      </SetCountContext.Provider>
    </CountContext.Provider>
  );
}
```