### PR TITLE
[FEATURE] Passing a function for draft or value for direct state usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,17 @@ export type ImmerHook<S> = [S, Updater<S>];
 
 export function useImmer<S = any>(
   initialValue: S | (() => S)
-): [S, (f: (draft: Draft<S>) => void | S) => void];
+): [S, (f: (draft: Draft<S> | S) => void | S) => void];
 
 export function useImmer(initialValue: any) {
   const [val, updateValue] = useState(initialValue);
   return [
     val,
     useCallback(updater => {
-      updateValue(produce(updater));
+      if(typeof updater === "function")
+        updateValue(produce(updater));
+      else
+        updateValue(updater);
     }, [])
   ];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type ImmerHook<S> = [S, Updater<S>];
 
 export function useImmer<S = any>(
   initialValue: S | (() => S)
-): [S, (f: (draft: Draft<S> | S) => void | S) => void];
+): [S, (f: ((draft: Draft<S> | S) => void) | S) => void];
 
 export function useImmer(initialValue: any) {
   const [val, updateValue] = useState(initialValue);


### PR DESCRIPTION
This PR enables the useImmer hook to be used as a normal useState passing a value as argument with still allowing the user to use the immer feature.

```javascript
const [state, setState] = useImmer([]);

// normal setState usage
    setState(["this", "is", "the", "new", "state"]);
// or immer usage
    setState( draft => {
        draft.push("my new item")
    });
```