### PR TITLE
Improve typings, updater will now return the new value instead of void

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,26 +4,34 @@ import { useState, useReducer, useCallback, useMemo, Dispatch } from "react";
 export type Reducer<S = any, A = any> = (
   draftState: Draft<S>,
   action: A
-) => void | S | (S extends undefined ? typeof nothing : never);
+) => void | (S extends undefined ? typeof nothing : S);
 
-export type Updater<S> = (f: (draft: Draft<S>) => void | S) => void;
+export type Updater<S> = (f: ((draft: Draft<S>) => void) | S) => Promise<S>;
 
 export type ImmerHook<S> = [S, Updater<S>];
 
-export function useImmer<S = any>(
-  initialValue: S | (() => S)
-): [S, (f: ((draft: Draft<S> | S) => void) | S) => void];
+export function useImmer<S = any>(initialValue: S | (() => S)): ImmerHook<S>;
 
 export function useImmer(initialValue: any) {
   const [val, updateValue] = useState(initialValue);
   return [
     val,
-    useCallback(updater => {
-      if(typeof updater === "function")
-        updateValue(produce(updater));
-      else
-        updateValue(updater);
-    }, [])
+    useCallback((updater) => {
+      if (typeof updater === "function") {
+        let nextValue: any;
+        return new Promise((resolve) => {
+          updateValue((curr: any) => {
+            nextValue = produce(curr, updater);
+            resolve(nextValue);
+            return nextValue;
+          });
+        });
+      } else {
+        const nextValue = updater;
+        updateValue(nextValue);
+        return Promise.resolve(nextValue);
+      }
+    }, []),
   ];
 }
 
@@ -32,7 +40,11 @@ export function useImmerReducer<S = any, A = any>(
   initialState: S,
   initialAction?: (initial: any) => S
 ): [S, Dispatch<A>];
-export function useImmerReducer(reducer: any, initialState: any, initialAction: any) {
+export function useImmerReducer(
+  reducer: any,
+  initialState: any,
+  initialAction: any
+) {
   const cachedReducer = useMemo(() => produce(reducer), [reducer]);
   return useReducer(cachedReducer, initialState as any, initialAction);
 }


### PR DESCRIPTION
* Drop the never usage in the reducer type definition.
* Add missing reuse of some types.
* Updater part of the `useImmer` hook will now return a promise for the updated value for better experience?


Please tell me what you think, Im not sure that it is a good behavior.. :)