### PR TITLE
fix: move immer to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
   },
   "devDependencies": {
     "@types/react": "^16.9.56",
-    "immer": "^9.0.0",
     "microbundle": "^0.12.4",
     "typescript": "^4.0.5"
+  },
+  "dependencies": {
+    "immer": "^9.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,9 +1895,9 @@ icss-replace-symbols@1.1.0, icss-replace-symbols@^1.1.0:
   integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
 
 immer@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.0.tgz#37d0e2beb928b495be48abf98d35cf76c64ee158"
-  integrity sha512-/L68D6hSjuQoeymW42UQLTMHvRZCapuSBBm0CfKbIyoqMDH+p8PHg9Cti3eBQA+tCRAOUOSBgn8Ji70YXWmBkw==
+  version "9.0.5"
+  resolved "https://registry.nlark.com/immer/download/immer-9.0.5.tgz?cache=0&sync_timestamp=1625499692644&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fimmer%2Fdownload%2Fimmer-9.0.5.tgz#a7154f34fe7064f15f00554cc94c66cc0bf453ec"
+  integrity sha1-pxVPNP5wZPFfAFVMyUxmzAv0U+w=
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Immer is in devDependencies,  so use-immer's node_modules miss immer.js, I must install immer.js manually.
Move immer to dependencies can solve this problem.