### PR TITLE
feat: upgrade immer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/mweststrate/use-immer#readme",
   "peerDependencies": {
-    "immer": ">=2.0.0",
+    "immer": ">=8.0.0",
     "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
use-immer uses `immer.freeze`, but immer export `freeze` since [8.0.0](https://github.com/immerjs/immer/compare/v7.0.15...v8.0.0)

so we should set immer version in peerDeps to `>=8.0.0`

